### PR TITLE
Edit groupname

### DIFF
--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -4,6 +4,11 @@ class Api::GroupsController < ApplicationController
     render json: groups
   end
 
+  def show
+    @group = Group.find(params[:id])
+    render json: @group
+  end
+
   def create
     @group = Group.new(group_params)
     if @group.save
@@ -11,6 +16,15 @@ class Api::GroupsController < ApplicationController
     else
       render json: { errors: @group.errors.full_messages }, status: :unprocessable_entity
     end
+  end
+
+  def update
+    @group = Group.find(params[:id])
+      if @group.update(group_params)
+        head :no_content
+      else
+        render json: { errors: @group.errors.full_messages }, status: :unprocessable_entity
+      end
   end
 
   private

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,3 +1,3 @@
 class Group < ApplicationRecord
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   root 'homes#index'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :api, format: 'json' do
-    resources :groups, only: [:index, :create, :update, :destroy]
+    resources :groups, only: [:index, :show, :create, :update, :destroy]
   end
 end

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -4,15 +4,15 @@ import {topUrl,groupUrl} from './constant.js';
 //// ローカル環境URLと実際のパスを連結し、ローカル環境下で対応できる様にした
 const localGroupUrl = (topUrl + groupUrl);
 
-export function groupList(){
+export const groupList = () => {
     return axios.get(localGroupUrl)
 }
 
-export function groupFind(id){
+export const groupFind = id => {
     return  axios.get(localGroupUrl + `${id}`)
 }
 
-export function groupCreate(group){
+export const groupCreate = group => {
     return axios
       .post(localGroupUrl, group)
       .then(response =>{
@@ -20,12 +20,12 @@ export function groupCreate(group){
       })
 }
 
-export function groupUpdate(group){
+export const groupUpdate = group => {
     return axios
       .patch(localGroupUrl + `${group.id}`, group)
 }
 
-export function ErrorMessage(error,group){
+export const ErrorMessage = (error,group) => {
   if(error.response.data && error.response.data.errors){
     group.errors = error.response.data.errors;
   }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -23,9 +23,6 @@ export function groupCreate(group){
 export function groupUpdate(group){
     return axios
       .patch(localGroupUrl + `${group.id}`, group)
-      .then(response =>{
-        location.href = topUrl;
-      })
 }
 
 export function ErrorMessage(error,group){

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -8,15 +8,28 @@ export function groupList(){
     return axios.get(localGroupUrl)
 }
 
-export function groupCreate(hoge){
+export function groupFind(id){
+    return  axios.get(localGroupUrl + `${id}`)
+}
+
+export function groupCreate(group){
     return axios
-            .post(localGroupUrl, hoge)
-            .then(response =>{
-              location.href = topUrl;
-            })
-            .catch(error => {
-              if(error.response.data && error.response.data.errors){
-                this.errors = error.response.data.errors;
-              }
-            });
+      .post(localGroupUrl, group)
+      .then(response =>{
+        location.href = topUrl;
+      })
+}
+
+export function groupUpdate(group){
+    return axios
+      .patch(localGroupUrl + `${group.id}`, group)
+      .then(response =>{
+        location.href = topUrl;
+      })
+}
+
+export function ErrorMessage(error,group){
+  if(error.response.data && error.response.data.errors){
+    group.errors = error.response.data.errors;
+  }
 }

--- a/frontend/src/components/ChatMain.vue
+++ b/frontend/src/components/ChatMain.vue
@@ -66,6 +66,10 @@ export default {
     },
     editGroupName: function(){
       groupUpdate(this.group)
+      .then(response =>{
+        this.show = true;
+        bus.$emit('sendSidebar');
+      })
       .catch(error => {
         ErrorMessage(error,this);
       });

--- a/frontend/src/components/ChatMain.vue
+++ b/frontend/src/components/ChatMain.vue
@@ -49,22 +49,22 @@ import {groupUpdate} from '../Api.js';
 import {ErrorMessage} from '../Api.js';
 
 export default {
-  data:function(){
+  data(){
     return{
       group: {},
       errors: '',
       show: true
     }
   },
-  mounted: function(){
+  mounted(){
     bus.$on('bus-event', this.displayGroupName)
   },
   methods: {
-    displayGroupName: function(sideGroup){
+    displayGroupName(sideGroup){
       this.show = true;
       this.group = sideGroup.data
     },
-    editGroupName: function(){
+    editGroupName(){
       groupUpdate(this.group)
       .then(response =>{
         this.show = true;

--- a/frontend/src/components/ChatMain.vue
+++ b/frontend/src/components/ChatMain.vue
@@ -1,16 +1,25 @@
 <template>
   <div class="chat">
     <div class="chat__head">
-      <div class="chat__head--left">
+      <div class="chat__head--left" v-show="show">
         <div class="chat-group-name">
-          チャットグループ名
+          {{ group.name }}
         </div>
-        <a class="short-font">
+        <a class="short-font" href="#open03" @click="show = !show">
           編集
         </a>
       </div>
+      <form @submit.prevent="editGroupName" class="chat-group-form" v-if="!show">
+        <input v-model="group.name" type="text" placeholder="グループ名" class="chat__footer__input">
+        <input type="submit" value="作成" class="chat__footer__submit group_submit">
+      </form>
+      <div class="error-message" v-if="errors.length != 0">
+        <ul v-for="e in errors" :key="e">
+          <li><font color="red">{{ e }}</font></li>
+        </ul>
+      </div>
       <div class="chat__head--right">
-        <a class="short-font">
+        <a class="short-font" href="#open03">
           チャットグループを削除する
         </a>
       </div>
@@ -34,6 +43,36 @@
     </div>
   </div>
 </template>
+<script>
+import {bus} from '../main.js';
+import {groupUpdate} from '../Api.js';
+import {ErrorMessage} from '../Api.js';
+
+export default {
+  data:function(){
+    return{
+      group: {},
+      errors: '',
+      show: true
+    }
+  },
+  mounted: function(){
+    bus.$on('bus-event', this.displayGroupName)
+  },
+  methods: {
+    displayGroupName: function(sideGroup){
+      this.show = true;
+      this.group = sideGroup.data
+    },
+    editGroupName: function(){
+      groupUpdate(this.group)
+      .catch(error => {
+        ErrorMessage(error,this);
+      });
+    }
+  }
+  };
+</script>
 <style lang="scss">
   .chat{
     float: right;
@@ -56,6 +95,9 @@
           display: inline-block;
           margin-right: 10px;
         }
+      }
+      .chat-group-form{
+        padding-left: 30px;
       }
       &--right{
         margin: 0 0 0 auto;
@@ -91,4 +133,11 @@
       }
     }
   }
+.none{
+  display: none;
+}
+
+.error-message{
+  float: left;
+}
 </style>

--- a/frontend/src/components/ModalWindow.vue
+++ b/frontend/src/components/ModalWindow.vue
@@ -21,8 +21,8 @@
   </div>
 </template>
 <script>
-import axios from 'axios';
 import {groupCreate} from '../Api.js';
+import {ErrorMessage} from '../Api.js';
 
 export default {
   data: function() {
@@ -35,7 +35,10 @@ export default {
   },
   methods: {
     createGroup: function(){
-      groupCreate(this.group);
+      groupCreate(this.group)
+      .catch(error => {
+        ErrorMessage(error,this);
+      });
     }
   }
 };

--- a/frontend/src/components/ModalWindow.vue
+++ b/frontend/src/components/ModalWindow.vue
@@ -25,7 +25,7 @@ import {groupCreate} from '../Api.js';
 import {ErrorMessage} from '../Api.js';
 
 export default {
-  data: function() {
+  data() {
     return{
       group: {
         name:''
@@ -34,7 +34,7 @@ export default {
     }
   },
   methods: {
-    createGroup: function(){
+    createGroup(){
       groupCreate(this.group)
       .catch(error => {
         ErrorMessage(error,this);

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -7,15 +7,17 @@
     </div>
     <div class="sidebar__list">
       <div  v-for="e in groups" :key="e.id" class="sidebar__list__group">
-        <div class="sidebar__list__group--name">
+        <a class="sidebar__list__group--name" v-on:click="setGroupinfo(e.id)">
           {{ e.name }}
-        </div>
+        </a>
       </div>
     </div>
   </div>
 </template>
 <script>
-import {groupList} from '../Api.js';
+import {groupList} from '../api.js';
+import {groupFind} from '../api.js';
+import {bus} from '../main.js';
 
 export default{
   data:function(){
@@ -27,6 +29,10 @@ export default{
     async fetchGroups () {
       const response = await groupList();
       this.groups = response.data
+    },
+    async setGroupinfo(id){
+      const sideGroup = await groupFind(id);
+      bus.$emit('bus-event', sideGroup);
     }
   },
   mounted(){

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -37,6 +37,7 @@ export default{
   },
   mounted(){
       this.fetchGroups()
+      bus.$on('sendSidebar', this.fetchGroups);
   }
 };
 </script>

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -20,7 +20,7 @@ import {groupFind} from '../api.js';
 import {bus} from '../main.js';
 
 export default{
-  data:function(){
+  data(){
     return{
       groups: []
     }

--- a/frontend/src/constant.js
+++ b/frontend/src/constant.js
@@ -1,3 +1,3 @@
 // ローカル環境URLを変数化
 export const topUrl = 'http://localhost:3000';
-export const groupUrl ='/api/groups';
+export const groupUrl ='/api/groups/';

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import App from './App.vue';
-
+export const bus = new Vue({});
 // App.vueをエントリとしてレンダリング
 new Vue({
   el: '#app',

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,5 +1,14 @@
 FactoryBot.define do
   factory :group do
     name {Faker::Team.name}
+    trait :invalid do
+      name {nil}
+    end
+  end
+  factory :test, class: Group do
+    name {"test"}
+  end
+  factory :test2, class: Group do
+    name {"test2"}
   end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -14,6 +14,17 @@ RSpec.describe Group, type: :model do
         group.valid?
         expect(group.errors[:name])
       end
+      it "is invalid with a duplicate name" do
+        # Group.create(
+        #   name: 'test'
+        # )
+        FactoryBot.create :test
+        group = Group.new(
+          name: 'test'
+        )
+        group.valid?
+        expect(group.valid?).to eq(false)
+      end
     end
   end
 end

--- a/spec/requests/groups_api_spec.rb
+++ b/spec/requests/groups_api_spec.rb
@@ -1,21 +1,44 @@
 require 'rails_helper'
 
 RSpec.describe "GroupApis", type: :request do
-  context "with valid attributes" do
-    it "adds a group" do
-      group_params = FactoryBot.attributes_for(:group)
-      expect{
+  describe 'POST #create' do
+    context "with valid attributes" do
+      it "adds a group" do
+        group_params = FactoryBot.attributes_for(:group)
+        expect{
+            post api_groups_path, params: {group: group_params}
+          }.to change(Group, :count).by(1)
+      end
+    end
+
+    context "with invalid attributes" do
+      it "does not add a group" do
+        group_params = FactoryBot.attributes_for(:group, :invalid)
+        expect{
           post api_groups_path, params: {group: group_params}
-        }.to change(Group, :count).by(1)
+        }.to_not change(Group, :count)
+      end
     end
   end
 
-  context "with invalid attributes" do
-    it "does not add a group" do
-      group_params = FactoryBot.attributes_for(:group, name: nil)
-      expect{
-        post api_groups_path, params: {group: group_params}
-      }.to_not change(Group, :count)
+  describe 'PUT #update' do
+    let(:test) { FactoryBot.create :test }
+    context "with valid attributes" do
+      it "edit a group" do
+        group_params = FactoryBot.attributes_for(:test2)
+        expect{
+            put api_group_path test, params: {group: group_params}
+          }.to change{ Group.find(test.id).name }.from('test').to('test2')
+      end
+    end
+
+    context "with invalid attributes" do
+      it "does not add edit a group" do
+       group_params = FactoryBot.attributes_for(:group, :invalid)
+        expect{
+            put api_group_path test, params: {group: group_params}
+          }.to_not change(Group.find(test.id), :name)
+      end
     end
   end
 end


### PR DESCRIPTION
# what
Groupの名前を編集出来る様に実装した
手順
1. サイドバーからgroupをクリックし、右側メイン画面に情報を表示
2. ヘッダーの[編集]をクリックすると、group名入力フォームが表示される
3. そのまま送信するとTopページへ遷移しgroup名が変更される

やったこと
・$emit,$onを使用し、SidebarコンポーネントからChatMainコンポーネントへgroupの情報を送信
・v-showを使用し、右ヘッダーの[編集]をクリックすると、group名がformに変更される
・api.jsでエラーメッセージ出力用関数を１つにまとめた「31~35行目」
・ユニットテストとリクエストスペック作成
・ユニットテストは、同じ名前のgroupが生成されたらエラーになる様再編集した

# Why
サービスの必須機能であるため

# スクリーンショット動画
https://gyazo.com/cdfd79ee4fa60c0f8691b261115fac02