### PR TITLE
[開発研修]chat-app グループ削除

### DIFF
--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -1,11 +1,12 @@
 class Api::GroupsController < ApplicationController
+  before_action :set_group, only: [:show,:update,:destroy]
+
   def index
     groups = Group.all
     render json: groups
   end
 
   def show
-    @group = Group.find(params[:id])
     render json: @group
   end
 
@@ -19,7 +20,6 @@ class Api::GroupsController < ApplicationController
   end
 
   def update
-    @group = Group.find(params[:id])
       if @group.update(group_params)
         head :no_content
       else
@@ -27,7 +27,16 @@ class Api::GroupsController < ApplicationController
       end
   end
 
+  def destroy
+    @group.destroy!
+    head :no_content
+  end
+
   private
+  def set_group
+    @group = Group.find(params[:id])
+  end
+
   def group_params
     params.require(:group).permit(:name)
   end

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -4,26 +4,24 @@ import {topUrl,groupUrl} from './constant.js';
 //// ローカル環境URLと実際のパスを連結し、ローカル環境下で対応できる様にした
 const localGroupUrl = (topUrl + groupUrl);
 
-export const groupList = () => {
-    return axios.get(localGroupUrl)
-}
+export const groupList = () =>
+  axios.get(localGroupUrl);
 
-export const groupFind = id => {
-    return  axios.get(localGroupUrl + `${id}`)
-}
+export const groupFind = id =>
+  axios.get(localGroupUrl + `${id}`);
 
-export const groupCreate = group => {
-    return axios
-      .post(localGroupUrl, group)
-      .then(response =>{
-        location.href = topUrl;
-      })
-}
+export const groupCreate = group =>
+  axios
+    .post(localGroupUrl, group)
+    .then(response =>{
+      location.href = topUrl;
+    });
 
-export const groupUpdate = group => {
-    return axios
-      .patch(localGroupUrl + `${group.id}`, group)
-}
+export const groupUpdate = group =>
+  axios.patch(localGroupUrl + `${group.id}`, group);
+
+export const groupDelete = id =>
+  axios.delete(`http://localhost:3000/api/groups/${id}`);
 
 export const ErrorMessage = (error,group) => {
   if(error.response.data && error.response.data.errors){

--- a/frontend/src/components/ChatMain.vue
+++ b/frontend/src/components/ChatMain.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="chat">
+  <div class="chat" v-show="exit">
     <div class="chat__head">
       <div class="chat__head--left" v-show="show">
         <div class="chat-group-name">
@@ -19,7 +19,7 @@
         </ul>
       </div>
       <div class="chat__head--right">
-        <a class="short-font" href="#open03">
+        <a class="short-font" href="#open03" v-on:click="deleteGroupData(group.id)">
           チャットグループを削除する
         </a>
       </div>
@@ -46,6 +46,7 @@
 <script>
 import {bus} from '../main.js';
 import {groupUpdate} from '../Api.js';
+import {groupDelete} from '../Api.js';
 import {ErrorMessage} from '../Api.js';
 
 export default {
@@ -53,7 +54,8 @@ export default {
     return{
       group: {},
       errors: '',
-      show: true
+      show: true,
+      exit: false
     }
   },
   mounted(){
@@ -62,6 +64,7 @@ export default {
   methods: {
     displayGroupName(sideGroup){
       this.show = true;
+      this.exit = true;
       this.group = sideGroup.data
     },
     editGroupName(){
@@ -73,9 +76,16 @@ export default {
       .catch(error => {
         ErrorMessage(error,this);
       });
+    },
+    deleteGroupData(id){
+      groupDelete(id)
+      .then(response =>{
+        bus.$emit('sendSidebar');
+        this.exit = false;
+      })
     }
   }
-  };
+};
 </script>
 <style lang="scss">
   .chat{

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -15,9 +15,6 @@ RSpec.describe Group, type: :model do
         expect(group.errors[:name])
       end
       it "is invalid with a duplicate name" do
-        # Group.create(
-        #   name: 'test'
-        # )
         FactoryBot.create :test
         group = Group.new(
           name: 'test'

--- a/spec/requests/groups_api_spec.rb
+++ b/spec/requests/groups_api_spec.rb
@@ -41,4 +41,13 @@ RSpec.describe "GroupApis", type: :request do
       end
     end
   end
+
+  describe 'DELETE #destroy' do
+    let!(:group) { FactoryBot.create :test }
+    it "add group" do
+      expect{
+        delete api_group_path group
+      }.to change(Group, :count).by(-1)
+    end
+  end
 end


### PR DESCRIPTION
# スクショ動画
https://gyazo.com/12a657478aec9f290780ee48c6d45daa
# what
groupの機能を実装した
右側ヘッダー削除ボタンをクリックすると、groupの削除が行える様になる
groupを削除した後はどのグループも選択していない状態なので、chatmainコンポーネントを表示しない状態にした

やったこと
・プループ削除機能実装
・group選択しない場合chatmainコンポーネントを表示しない
・api.jsの関数内のreturn部分の省略
・リクエストスペック

# why
サービスに必須となる機能であるため