### PR TITLE
[開発研修]chat-app メッセージ表示

### DIFF
--- a/app/channels/message_channel.rb
+++ b/app/channels/message_channel.rb
@@ -1,0 +1,15 @@
+class MessageChannel < ApplicationCable::Channel
+  def subscribed
+   stream_from "message_channel"
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+
+  def speak(data)
+    #speakアクションが呼ばれたら、messageをデータベースに保存
+    Message.create! content: data['message'], group_id: data['group_id']
+    ActionCable.server.broadcast 'message_channel', message: data['message']
+  end
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,11 @@
+class Api::MessagesController < ApplicationController
+  def index
+    @group = Group.find(params[:group_id])
+    @messages = @group.messages.all
+    render json: @messages
+  end
+
+  def message_params
+    params.require(:message).permit(:content)
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,3 +1,4 @@
 class Group < ApplicationRecord
+  has_many :messages
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,2 @@
+class Message < ApplicationRecord
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,2 +1,4 @@
 class Message < ApplicationRecord
+  belongs_to :group
+  validates :content, presence: true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   root 'homes#index'
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  mount ActionCable.server => '/cable'
   namespace :api, format: 'json' do
-    resources :groups, only: [:index, :show, :create, :update, :destroy]
+    resources :groups, only: [:index, :show, :create, :update, :destroy] do
+      resources :messages, only: [:index]
+    end
   end
 end

--- a/db/migrate/20191017011556_create_messages.rb
+++ b/db/migrate/20191017011556_create_messages.rb
@@ -1,0 +1,9 @@
+class CreateMessages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :messages do |t|
+      t.string :content, null: false
+      t.references :group, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_07_043209) do
+ActiveRecord::Schema.define(version: 2019_10_17_011556) do
 
   create_table "groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -18,4 +18,13 @@ ActiveRecord::Schema.define(version: 2019_10_07_043209) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "content", null: false
+    t.bigint "group_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_messages_on_group_id"
+  end
+
+  add_foreign_key "messages", "groups"
 end

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1272,6 +1272,12 @@
       "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
       "dev": true
     },
+    "actioncable": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/actioncable/-/actioncable-5.2.3.tgz",
+      "integrity": "sha512-KNdZHRDu92VDSO7SOEJS8Bf5G//LZZLz5e6m7mv8Wjafe9Svdp/DPJ/DpO7rJmPAlKcLAYwi/R7pNJ/VCHV1FQ==",
+      "dev": true
+    },
     "ajv": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@babel/core": "^7.6.2",
     "@babel/preset-env": "^7.6.2",
+    "actioncable": "^5.2.3",
     "axios": "^0.19.0",
     "babel": "^6.23.0",
     "babel-loader": "^8.0.6",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -23,8 +23,13 @@ export const groupUpdate = group =>
 export const groupDelete = id =>
   axios.delete(`http://localhost:3000/api/groups/${id}`);
 
+// エラー処理
 export const ErrorMessage = (error,group) => {
   if(error.response.data && error.response.data.errors){
     group.errors = error.response.data.errors;
   }
 }
+
+// メッセージ一覧表示
+export const messageList = group_id =>
+  axios.get(localGroupUrl + `${group_id}` + `/messages`)

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,7 +1,11 @@
 import Vue from 'vue';
 import App from './App.vue';
+import ActionCable from 'actioncable';
 export const bus = new Vue({});
 // App.vueをエントリとしてレンダリング
+const cable = ActionCable.createConsumer('ws:localhost:3000/cable');
+Vue.prototype.$cable = cable;
+
 new Vue({
   el: '#app',
   render: h => h(App)

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :message do
+    content {Faker::Lorem.sentence}
+    group
+  end
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Message, type: :model do
+    describe '#create' do
+      context 'can save' do
+        it 'is invalid with content' do
+          expect(build(:message)).to be_valid
+        end
+      end
+
+      context 'can not save' do
+        it 'is invalid without content' do
+          message = build(:message, content: nil)
+          message.valid?
+          expect(message.errors[:content])
+        end
+
+        it 'is invalid without group_id' do
+          message = build(:message, group_id: nil)
+          message.valid?
+          expect(message.errors[:group])
+        end
+      end
+    end
+end


### PR DESCRIPTION
# スクショ動画
https://gyazo.com/fc3bdda88731e1fd3bc53f1949374790

# What
メッセージ送信機能をaction_cableを使って実装した
流れ
・サイドバーのgroup選択後、該当groupのmessage一覧を表示
・formでmessage送信すると非同期でDBに保存される
・message送信後に再度message一覧を表示し入力欄の文字列を空にする

やったこと
・message送信機能作成、action_cableを使用
・message一覧表示機能作成、group選択後とmessage送信後に発動する
・messageモデルの単体テストを作成

# Why
サービスの必須機能であるため